### PR TITLE
fix: change entry_id to id

### DIFF
--- a/src/Tags/AnchorNavigation.php
+++ b/src/Tags/AnchorNavigation.php
@@ -27,7 +27,7 @@ class AnchorNavigation extends Tags
             return null;
         }
 
-        if (! $this->entry = $this->context->get('entry_id')->augmentable()) {
+        if (! $this->entry = $this->context->get('id')->augmentable()) {
             return null;
         }
 


### PR DESCRIPTION
In einem normalen Seiteneintrag findet er 'entry_id' nicht. Soweit ich das verstehe ist hier ja die id der Seite gesucht. 
Ich habe somit den Parameter angepasst.